### PR TITLE
Support for RubySaml 0.8.x added

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,20 +1,21 @@
 PATH
   remote: .
   specs:
-    omniauth-saml (1.1.0)
-      omniauth (~> 1.1)
-      ruby-saml (~> 0.7.3)
+    omniauth-saml (1.2.0)
+      omniauth (~> 1.2)
+      ruby-saml (~> 0.8.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    canonix (0.1.1)
     diff-lcs (1.2.4)
-    hashie (2.0.5)
-    macaddr (1.6.7)
+    hashie (2.1.0)
+    macaddr (1.7.0)
       systemu (~> 2.6.2)
+    mini_portile (0.5.3)
     multi_json (1.3.7)
-    nokogiri (1.5.11)
+    nokogiri (1.6.1)
+      mini_portile (~> 0.5.0)
     omniauth (1.2.1)
       hashie (>= 1.2, < 3)
       rack (~> 1.0)
@@ -29,9 +30,8 @@ GEM
     rspec-expectations (2.14.4)
       diff-lcs (>= 1.1.3, < 2.0)
     rspec-mocks (2.14.4)
-    ruby-saml (0.7.3)
-      canonix (= 0.1.1)
-      nokogiri (~> 1.5.0)
+    ruby-saml (0.8.1)
+      nokogiri (>= 1.5.0)
       uuid (~> 2.3)
     simplecov (0.7.1)
       multi_json (~> 1.0)

--- a/lib/omniauth/strategies/saml.rb
+++ b/lib/omniauth/strategies/saml.rb
@@ -18,8 +18,8 @@ module OmniAuth
           additional_params[mapped_param_key] = request.params[request_param_key.to_s] if request.params.has_key?(request_param_key.to_s)
         end if runtime_request_parameters
 
-        authn_request = Onelogin::Saml::Authrequest.new
-        settings = Onelogin::Saml::Settings.new(options)
+        authn_request = OneLogin::RubySaml::Authrequest.new
+        settings = OneLogin::RubySaml::Settings.new(options)
 
         redirect(authn_request.create(settings, additional_params))
       end
@@ -29,8 +29,8 @@ module OmniAuth
           raise OmniAuth::Strategies::SAML::ValidationError.new("SAML response missing")
         end
 
-        response = Onelogin::Saml::Response.new(request.params['SAMLResponse'], options)
-        response.settings = Onelogin::Saml::Settings.new(options)
+        response = OneLogin::RubySaml::Response.new(request.params['SAMLResponse'], options)
+        response.settings = OneLogin::RubySaml::Settings.new(options)
 
         @name_id = response.name_id
         @attributes = response.attributes
@@ -44,7 +44,7 @@ module OmniAuth
         super
       rescue OmniAuth::Strategies::SAML::ValidationError
         fail!(:invalid_ticket, $!)
-      rescue Onelogin::Saml::ValidationError
+      rescue OneLogin::RubySaml::ValidationError
         fail!(:invalid_ticket, $!)
       end
 
@@ -54,8 +54,8 @@ module OmniAuth
           @env['omniauth.strategy'] ||= self
           setup_phase
 
-          response = Onelogin::Saml::Metadata.new
-          settings = Onelogin::Saml::Settings.new(options)
+          response = OneLogin::RubySaml::Metadata.new
+          settings = OneLogin::RubySaml::Settings.new(options)
           Rack::Response.new(response.generate(settings), 200, { "Content-Type" => "application/xml" }).finish
         else
           call_app!

--- a/omniauth-saml.gemspec
+++ b/omniauth-saml.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |gem|
   gem.homepage      = 'https://github.com/PracticallyGreen/omniauth-saml'
 
   gem.add_runtime_dependency 'omniauth', '~> 1.2'
-  gem.add_runtime_dependency 'ruby-saml', '~> 0.7.3'
+  gem.add_runtime_dependency 'ruby-saml', '~> 0.8.0'
 
   gem.add_development_dependency 'rspec', '~> 2.8'
   gem.add_development_dependency 'simplecov', '~> 0.6'


### PR DESCRIPTION
Fix to support RubySaml 0.8.x.
Fixes issue: PracticallyGreen/omniauth-saml#25

The multiple value support as mentioned by @borgand should still be implemented.
Would it be possible to create a separate issue for that? As the lack of RubySaml 0.8 support blocks the upgrade of Nokogiri to name just one.