### PR TITLE
Update ruby-saml gem and naming

### DIFF
--- a/lib/omniauth-saml/version.rb
+++ b/lib/omniauth-saml/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module SAML
-    VERSION = '1.2.0'
+    VERSION = '2.0.0'
   end
 end

--- a/lib/omniauth/strategies/saml.rb
+++ b/lib/omniauth/strategies/saml.rb
@@ -18,8 +18,8 @@ module OmniAuth
           additional_params[mapped_param_key] = request.params[request_param_key.to_s] if request.params.has_key?(request_param_key.to_s)
         end if runtime_request_parameters
 
-        authn_request = Onelogin::Saml::Authrequest.new
-        settings = Onelogin::Saml::Settings.new(options)
+        authn_request = OneLogin::RubySaml::Authrequest.new
+        settings = OneLogin::RubySaml::Settings.new(options)
 
         redirect(authn_request.create(settings, additional_params))
       end
@@ -29,8 +29,8 @@ module OmniAuth
           raise OmniAuth::Strategies::SAML::ValidationError.new("SAML response missing")
         end
 
-        response = Onelogin::Saml::Response.new(request.params['SAMLResponse'], options)
-        response.settings = Onelogin::Saml::Settings.new(options)
+        response = OneLogin::RubySaml::Response.new(request.params['SAMLResponse'], options)
+        response.settings = OneLogin::RubySaml::Settings.new(options)
 
         @name_id = response.name_id
         @attributes = response.attributes
@@ -42,10 +42,9 @@ module OmniAuth
         response.validate!
 
         super
-      rescue OmniAuth::Strategies::SAML::ValidationError
-        fail!(:invalid_ticket, $!)
-      rescue Onelogin::Saml::ValidationError
-        fail!(:invalid_ticket, $!)
+      rescue OmniAuth::Strategies::SAML::ValidationError, OneLogin::RubySaml::ValidationError => e
+        Airbrake.notify_or_raise e, parameters: {document: response.document, options: options}, slack: true
+        fail!(:invalid_ticket, e)
       end
 
       def other_phase
@@ -54,8 +53,8 @@ module OmniAuth
           @env['omniauth.strategy'] ||= self
           setup_phase
 
-          response = Onelogin::Saml::Metadata.new
-          settings = Onelogin::Saml::Settings.new(options)
+          response = OneLogin::RubySaml::Metadata.new
+          settings = OneLogin::RubySaml::Settings.new(options)
           Rack::Response.new(response.generate(settings), 200, { "Content-Type" => "application/xml" }).finish
         else
           call_app!

--- a/omniauth-saml.gemspec
+++ b/omniauth-saml.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |gem|
   gem.homepage      = 'https://github.com/PracticallyGreen/omniauth-saml'
 
   gem.add_runtime_dependency 'omniauth', '~> 1.2'
-  gem.add_runtime_dependency 'ruby-saml', '~> 0.7.3'
+  gem.add_runtime_dependency 'ruby-saml', '> 0.7.3'
 
   gem.add_development_dependency 'rspec', '~> 2.8'
   gem.add_development_dependency 'simplecov', '~> 0.6'


### PR DESCRIPTION
Earlier versions of the ruby-saml gem lock other gems that have been updated and are needed by us, maybe others.