### PR TITLE
Validate an idp fingerprint using a configurable lambda

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ A generic SAML strategy for OmniAuth.
 
 https://github.com/PracticallyGreen/omniauth-saml
 
+## 1.3.0 (2014-14-10)
+
+* add `idp_cert_fingerprint_validator` option
+
 ## 1.2.0 (2014-03-19)
 
 * provide SP metadata at `/auth/saml/metadata`

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ use OmniAuth::Strategies::SAML,
   :idp_sso_target_url_runtime_params  => {:original_request_param => :mapped_idp_param},
   :idp_cert                           => "-----BEGIN CERTIFICATE-----\n...-----END CERTIFICATE-----",
   :idp_cert_fingerprint               => "E7:91:B2:E1:...",
+  :idp_cert_fingerprint_validator     => lambda { |fingerprint| fingerprint },
   :name_identifier_format             => "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress"
 ```
 
@@ -44,6 +45,7 @@ Rails.application.config.middleware.use OmniAuth::Builder do
     :idp_sso_target_url_runtime_params  => {:original_request_param => :mapped_idp_param},
     :idp_cert                           => "-----BEGIN CERTIFICATE-----\n...-----END CERTIFICATE-----",
     :idp_cert_fingerprint               => "E7:91:B2:E1:...",
+    :idp_cert_fingerprint_validator     => lambda { |fingerprint| fingerprint },
     :name_identifier_format             => "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress"
 end
 ```
@@ -73,12 +75,16 @@ The service provider metadata used to ease configuration of the SAML SP in the I
   `original_param_value`. Optional.
 
 * `:idp_cert` - The identity provider's certificate in PEM format. Takes precedence
-  over the fingerprint option below. This option or `:idp_cert_fingerprint` must
+  over the fingerprint option below. This option or `:idp_cert_fingerprint` or `:idp_cert_fingerprint_validator` must
   be present.
 
 * `:idp_cert_fingerprint` - The SHA1 fingerprint of the certificate, e.g.
   "90:CC:16:F0:8D:...". This is provided from the identity provider when setting up
-  the relationship. This option or `:idp_cert` must be present.
+  the relationship. This option or `:idp_cert` or `:idp_cert_fingerprint_validator` MUST be present.
+
+* `:idp_cert_fingerprint_validator` - A lambda that MUST accept one parameter
+  (the fingerprint), verify if it is valid and return it if successful. This option
+  or `:idp_cert` or `:idp_cert_fingerprint` MUST be present.
 
 * `:name_identifier_format` - Used during SP-initiated SSO. Describes the format of
   the username required by this application. If you need the email address, use
@@ -92,7 +98,7 @@ The service provider metadata used to ease configuration of the SAML SP in the I
 
 ## Authors
 
-Authored by [Rajiv Aaron Manglani](http://www.rajivmanglani.com/), Raecoo Cao, Todd W Saxton, Ryan Wilcox, Steven Anderson, Nikos Dimitrakopoulos, and Rudolf Vriend.
+Authored by [Rajiv Aaron Manglani](http://www.rajivmanglani.com/), Raecoo Cao, Todd W Saxton, Ryan Wilcox, Steven Anderson, Nikos Dimitrakopoulos, Rudolf Vriend and [Bruno Pedro](http://brunopedro.com/).
 
 ## License
 

--- a/lib/omniauth-saml/version.rb
+++ b/lib/omniauth-saml/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module SAML
-    VERSION = '1.2.0'
+    VERSION = '1.3.0'
   end
 end

--- a/lib/omniauth/strategies/saml.rb
+++ b/lib/omniauth/strategies/saml.rb
@@ -29,6 +29,16 @@ module OmniAuth
           raise OmniAuth::Strategies::SAML::ValidationError.new("SAML response missing")
         end
 
+        # Call a fingerprint validation method if there's one
+        if options.idp_cert_fingerprint_validate_method
+          fingerprint_exists = eval(options.idp_cert_fingerprint_validate_method << '(\'' << response_fingerprint << '\')')
+          unless fingerprint_exists
+            raise OmniAuth::Strategies::SAML::ValidationError.new("Non-existent fingerprint")
+          end
+          # id_cert_fingerprint becomes the given fingerprint if it exists
+          options.idp_cert_fingerprint = fingerprint_exists
+        end
+
         response = Onelogin::Saml::Response.new(request.params['SAMLResponse'], options)
         response.settings = Onelogin::Saml::Settings.new(options)
 
@@ -46,6 +56,18 @@ module OmniAuth
         fail!(:invalid_ticket, $!)
       rescue Onelogin::Saml::ValidationError
         fail!(:invalid_ticket, $!)
+      end
+
+      # Obtain an idp certificate fingerprint from the response.
+      def response_fingerprint
+        response = request.params['SAMLResponse']
+        response = (response =~ /^</) ? response : Base64.decode64(response)
+        document = XMLSecurity::SignedDocument::new(response)
+        cert_element = REXML::XPath.first(document, "//ds:X509Certificate", { "ds"=> 'http://www.w3.org/2000/09/xmldsig#' })
+        base64_cert = cert_element.text
+        cert_text = Base64.decode64(base64_cert)
+        cert = OpenSSL::X509::Certificate.new(cert_text)
+        Digest::SHA1.hexdigest(cert.to_der).upcase.scan(/../).join(':')
       end
 
       def other_phase

--- a/lib/omniauth/strategies/saml.rb
+++ b/lib/omniauth/strategies/saml.rb
@@ -30,8 +30,8 @@ module OmniAuth
         end
 
         # Call a fingerprint validation method if there's one
-        if options.idp_cert_fingerprint_validate_method
-          fingerprint_exists = eval(options.idp_cert_fingerprint_validate_method << '(\'' << response_fingerprint << '\')')
+        if options.idp_cert_fingerprint_validator
+          fingerprint_exists = options.idp_cert_fingerprint_validator[response_fingerprint]
           unless fingerprint_exists
             raise OmniAuth::Strategies::SAML::ValidationError.new("Non-existent fingerprint")
           end

--- a/omniauth-saml.gemspec
+++ b/omniauth-saml.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |gem|
   gem.email         = 'rajiv@alum.mit.edu'
   gem.homepage      = 'https://github.com/PracticallyGreen/omniauth-saml'
 
-  gem.add_runtime_dependency 'omniauth', '~> 1.2'
+  gem.add_runtime_dependency 'omniauth', '~> 1.1'
   gem.add_runtime_dependency 'ruby-saml', '~> 0.7.3'
 
   gem.add_development_dependency 'rspec', '~> 2.8'

--- a/spec/omniauth/strategies/saml_spec.rb
+++ b/spec/omniauth/strategies/saml_spec.rb
@@ -84,6 +84,27 @@ describe OmniAuth::Strategies::SAML, :type => :strategy do
       end
     end
 
+    context "when fingerprint is empty and there's a fingerprint validator" do
+      before :each do
+        saml_options.delete(:idp_cert_fingerprint)
+        saml_options[:idp_cert_fingerprint_validator] = lambda { |fingerprint| "C1:59:74:2B:E8:0C:6C:A9:41:0F:6E:83:F6:D1:52:25:45:58:89:FB" }
+        post_xml
+      end
+
+      it "should set the uid to the nameID in the SAML response" do
+        auth_hash['uid'].should == '_1f6fcf6be5e13b08b1e3610e7ff59f205fbd814f23'
+      end
+
+      it "should set the raw info to all attributes" do
+        auth_hash['extra']['raw_info'].to_hash.should == {
+          'first_name'   => 'Rajiv',
+          'last_name'    => 'Manglani',
+          'email'        => 'user@example.com',
+          'company_name' => 'Example Company'
+        }
+      end
+    end
+
     context "when there is no SAMLResponse parameter" do
       before :each do
         post '/auth/saml/callback'


### PR DESCRIPTION
## What?

If the option `idp_cert_fingerprint_validator` is present, it's a one parameter lambda that verifies if the idp fingerprint coming from the request is valid. The lambda is called and, if the response is successful, the fingerprint is valid and is used thereafter.

## Why?

In some situations there's the need to support **multiple** fingerprints in a dynamic way. Fingerprints might be available on a database or elsewhere and the best way to abstract their validation is to provide a method that will verify if a given fingerprint exists.

This feature will, in fact, support multiple dynamic fingerprint usage without prior configuration.

## Notes

This feature shouldn't break any existing functionality. It will only be used and activated if the `idp_cert_fingerprint_validator` option is present.