### PR TITLE
Add options for outbound auth requests

### DIFF
--- a/lib/omniauth/strategies/saml.rb
+++ b/lib/omniauth/strategies/saml.rb
@@ -9,6 +9,7 @@ module OmniAuth
       option :name_identifier_format, nil
       option :idp_sso_target_url_runtime_params, {}
       option :compress_request, nil
+      option :force_authn, nil
 
       def request_phase
         options[:assertion_consumer_service_url] ||= callback_url

--- a/lib/omniauth/strategies/saml.rb
+++ b/lib/omniauth/strategies/saml.rb
@@ -8,6 +8,7 @@ module OmniAuth
 
       option :name_identifier_format, nil
       option :idp_sso_target_url_runtime_params, {}
+      option :compress_request, true
 
       def request_phase
         options[:assertion_consumer_service_url] ||= callback_url

--- a/lib/omniauth/strategies/saml.rb
+++ b/lib/omniauth/strategies/saml.rb
@@ -8,7 +8,7 @@ module OmniAuth
 
       option :name_identifier_format, nil
       option :idp_sso_target_url_runtime_params, {}
-      option :compress_request, true
+      option :compress_request, nil
 
       def request_phase
         options[:assertion_consumer_service_url] ||= callback_url


### PR DESCRIPTION
`ruby-saml` supports configuring `compress_request` and `force_authn` so add support for those in outgoing auth requests. 