### PR TITLE
Update to ruby-saml 0.9.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,20 +1,20 @@
 PATH
   remote: .
   specs:
-    omniauth-saml (1.3.0)
+    omniauth-saml (1.4.0)
       omniauth (~> 1.1)
-      ruby-saml (~> 0.8.1)
+      ruby-saml (~> 0.9.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
     diff-lcs (1.2.4)
-    hashie (3.3.2)
+    hashie (3.4.0)
     macaddr (1.7.1)
       systemu (~> 2.6.2)
     mini_portile (0.6.2)
     multi_json (1.3.7)
-    nokogiri (1.6.5)
+    nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
     omniauth (1.2.2)
       hashie (>= 1.2, < 4)
@@ -30,14 +30,14 @@ GEM
     rspec-expectations (2.14.4)
       diff-lcs (>= 1.1.3, < 2.0)
     rspec-mocks (2.14.4)
-    ruby-saml (0.8.1)
-      nokogiri (>= 1.5.0)
+    ruby-saml (0.9.1)
+      nokogiri (~> 1.6.0)
       uuid (~> 2.3)
     simplecov (0.7.1)
       multi_json (~> 1.0)
       simplecov-html (~> 0.7.1)
     simplecov-html (0.7.1)
-    systemu (2.6.4)
+    systemu (2.6.5)
     uuid (2.3.7)
       macaddr (~> 1.0)
 

--- a/lib/omniauth-saml/version.rb
+++ b/lib/omniauth-saml/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module SAML
-    VERSION = '1.3.1'
+    VERSION = '1.4.0'
   end
 end

--- a/omniauth-saml.gemspec
+++ b/omniauth-saml.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |gem|
   gem.homepage      = 'https://github.com/PracticallyGreen/omniauth-saml'
 
   gem.add_runtime_dependency 'omniauth', '~> 1.1'
-  gem.add_runtime_dependency 'ruby-saml', '~> 0.8.1'
+  gem.add_runtime_dependency 'ruby-saml', '~> 0.9.1'
 
   gem.add_development_dependency 'rspec', '~> 2.8'
   gem.add_development_dependency 'simplecov', '~> 0.6'

--- a/spec/omniauth/strategies/saml_spec.rb
+++ b/spec/omniauth/strategies/saml_spec.rb
@@ -75,11 +75,11 @@ describe OmniAuth::Strategies::SAML, :type => :strategy do
       end
 
       it "should set the raw info to all attributes" do
-        auth_hash['extra']['raw_info'].to_hash.should == {
-          'first_name'   => 'Rajiv',
-          'last_name'    => 'Manglani',
-          'email'        => 'user@example.com',
-          'company_name' => 'Example Company',
+        auth_hash['extra']['raw_info'].to_h.should == {
+          'first_name'   => ['Rajiv'],
+          'last_name'    => ['Manglani'],
+          'email'        => ['user@example.com'],
+          'company_name' => ['Example Company'],
           'fingerprint'  => saml_options[:idp_cert_fingerprint]
         }
       end
@@ -97,11 +97,11 @@ describe OmniAuth::Strategies::SAML, :type => :strategy do
       end
 
       it "should set the raw info to all attributes" do
-        auth_hash['extra']['raw_info'].to_hash.should == {
-          'first_name'   => 'Rajiv',
-          'last_name'    => 'Manglani',
-          'email'        => 'user@example.com',
-          'company_name' => 'Example Company',
+        auth_hash['extra']['raw_info'].to_h.should == {
+          'first_name'   => ['Rajiv'],
+          'last_name'    => ['Manglani'],
+          'email'        => ['user@example.com'],
+          'company_name' => ['Example Company'],
           'fingerprint'  => 'C1:59:74:2B:E8:0C:6C:A9:41:0F:6E:83:F6:D1:52:25:45:58:89:FB'
         }
       end


### PR DESCRIPTION
This later version of ruby-saml supports more security options in the
saml assertion and metadata.