### PR TITLE
Upgrade ruby-saml dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,20 +1,20 @@
 PATH
   remote: .
   specs:
-    omniauth-saml (1.3.0)
+    omniauth-saml (1.3.1)
       omniauth (~> 1.1)
-      ruby-saml (~> 0.8.1)
+      ruby-saml (~> 0.9.2)
 
 GEM
   remote: https://rubygems.org/
   specs:
     diff-lcs (1.2.4)
-    hashie (3.3.2)
+    hashie (3.4.1)
     macaddr (1.7.1)
       systemu (~> 2.6.2)
     mini_portile (0.6.2)
     multi_json (1.3.7)
-    nokogiri (1.6.5)
+    nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
     omniauth (1.2.2)
       hashie (>= 1.2, < 4)
@@ -30,14 +30,14 @@ GEM
     rspec-expectations (2.14.4)
       diff-lcs (>= 1.1.3, < 2.0)
     rspec-mocks (2.14.4)
-    ruby-saml (0.8.1)
-      nokogiri (>= 1.5.0)
+    ruby-saml (0.9.2)
+      nokogiri (>= 1.5.10)
       uuid (~> 2.3)
     simplecov (0.7.1)
       multi_json (~> 1.0)
       simplecov-html (~> 0.7.1)
     simplecov-html (0.7.1)
-    systemu (2.6.4)
+    systemu (2.6.5)
     uuid (2.3.7)
       macaddr (~> 1.0)
 

--- a/omniauth-saml.gemspec
+++ b/omniauth-saml.gemspec
@@ -12,12 +12,12 @@ Gem::Specification.new do |gem|
   gem.homepage      = 'https://github.com/PracticallyGreen/omniauth-saml'
 
   gem.add_runtime_dependency 'omniauth', '~> 1.1'
-  gem.add_runtime_dependency 'ruby-saml', '~> 0.8.1'
+  gem.add_runtime_dependency 'ruby-saml', '~> 0.9.2'
 
   gem.add_development_dependency 'rspec', '~> 2.8'
   gem.add_development_dependency 'simplecov', '~> 0.6'
   gem.add_development_dependency 'rack-test', '~> 0.6'
-
+  
   gem.files         = ['README.md', 'CHANGELOG.md'] + Dir['lib/**/*.rb']
   gem.test_files    = Dir['spec/**/*.rb']
   gem.require_paths = ["lib"]

--- a/spec/omniauth/strategies/saml_spec.rb
+++ b/spec/omniauth/strategies/saml_spec.rb
@@ -75,11 +75,11 @@ describe OmniAuth::Strategies::SAML, :type => :strategy do
       end
 
       it "should set the raw info to all attributes" do
-        auth_hash['extra']['raw_info'].to_hash.should == {
-          'first_name'   => 'Rajiv',
-          'last_name'    => 'Manglani',
-          'email'        => 'user@example.com',
-          'company_name' => 'Example Company',
+        auth_hash['extra']['raw_info'].all.to_hash.should == {
+          'first_name'   => ['Rajiv'],
+          'last_name'    => ['Manglani'],
+          'email'        => ['user@example.com'],
+          'company_name' => ['Example Company'],
           'fingerprint'  => saml_options[:idp_cert_fingerprint]
         }
       end
@@ -97,11 +97,11 @@ describe OmniAuth::Strategies::SAML, :type => :strategy do
       end
 
       it "should set the raw info to all attributes" do
-        auth_hash['extra']['raw_info'].to_hash.should == {
-          'first_name'   => 'Rajiv',
-          'last_name'    => 'Manglani',
-          'email'        => 'user@example.com',
-          'company_name' => 'Example Company',
+        auth_hash['extra']['raw_info'].all.to_hash.should == {
+          'first_name'   => ['Rajiv'],
+          'last_name'    => ['Manglani'],
+          'email'        => ['user@example.com'],
+          'company_name' => ['Example Company'],
           'fingerprint'  => 'C1:59:74:2B:E8:0C:6C:A9:41:0F:6E:83:F6:D1:52:25:45:58:89:FB'
         }
       end


### PR DESCRIPTION
I've just upgrade ruby-saml dependency and updated the tests to pass on.

The upgrade was necessary due a bug we found in our stack and we were not able to parse an offline saml schema:
- Torquebox 3.2.1 
- JRuby 
- Nokogiri 1.6.1 (patched - we can't update because of Torquebox)

So the only solution was upgrade some of gems we are dependent and omniauth-saml was one of then.