### PR TITLE
Configurable attribute_consuming_service

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,12 @@ The service provider metadata used to ease configuration of the SAML SP in the I
   If not specified, the IdP is free to choose the name identifier format used
   in the response. Optional.
 
+* `:request_attributes` - Used to build the metadata file to inform the IdP to send certain attributes
+  along with the SAMLResponse messages. Defaults to requesting `name`, `first_name`, `last_name` and `email`
+  attributes. See the `OneLogin::RubySaml::AttributeService` class in the [Ruby SAML gem](https://github.com/onelogin/ruby-saml) for the available options for each attribute. Set to `{}` to disable this from metadata.
+
+* `:attribute_service_name` - Name for the attribute service. Defaults to `Required attributes`.
+
 * See the `OneLogin::RubySaml::Settings` class in the [Ruby SAML gem](https://github.com/onelogin/ruby-saml) for additional supported options.
 
 ## Devise Integration

--- a/lib/omniauth/strategies/saml.rb
+++ b/lib/omniauth/strategies/saml.rb
@@ -8,6 +8,13 @@ module OmniAuth
 
       option :name_identifier_format, nil
       option :idp_sso_target_url_runtime_params, {}
+      option :request_attributes, [
+        { name: 'email', name_format: 'urn:oasis:names:tc:SAML:2.0:attrname-format:basic', friendly_name: 'Email address' },
+        { name: 'name', name_format: 'urn:oasis:names:tc:SAML:2.0:attrname-format:basic', friendly_name: 'Full name' },
+        { name: 'first_name', name_format: 'urn:oasis:names:tc:SAML:2.0:attrname-format:basic', friendly_name: 'Given name' },
+        { name: 'last_name', name_format: 'urn:oasis:names:tc:SAML:2.0:attrname-format:basic', friendly_name: 'Family name' }
+      ]
+      option :attribute_service_name, 'Required attributes'
 
       def request_phase
         options[:assertion_consumer_service_url] ||= callback_url
@@ -81,6 +88,12 @@ module OmniAuth
 
           response = OneLogin::RubySaml::Metadata.new
           settings = OneLogin::RubySaml::Settings.new(options)
+          if options.request_attributes.length > 0
+            settings.attribute_consuming_service.service_name options.attribute_service_name
+            options.request_attributes.each do |attribute|
+              settings.attribute_consuming_service.add_attribute attribute
+            end
+          end
           Rack::Response.new(response.generate(settings), 200, { "Content-Type" => "application/xml" }).finish
         else
           call_app!

--- a/spec/omniauth/strategies/saml_spec.rb
+++ b/spec/omniauth/strategies/saml_spec.rb
@@ -20,7 +20,14 @@ describe OmniAuth::Strategies::SAML, :type => :strategy do
       :idp_sso_target_url                 => "https://idp.sso.target_url/signon/29490",
       :idp_cert_fingerprint               => "C1:59:74:2B:E8:0C:6C:A9:41:0F:6E:83:F6:D1:52:25:45:58:89:FB",
       :idp_sso_target_url_runtime_params  => {:original_param_key => :mapped_param_key},
-      :name_identifier_format             => "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress"
+      :name_identifier_format             => "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress",
+      :request_attributes                 => [
+        { name: 'email', name_format: 'urn:oasis:names:tc:SAML:2.0:attrname-format:basic', friendly_name: 'Email address' },
+        { name: 'name', name_format: 'urn:oasis:names:tc:SAML:2.0:attrname-format:basic', friendly_name: 'Full name' },
+        { name: 'first_name', name_format: 'urn:oasis:names:tc:SAML:2.0:attrname-format:basic', friendly_name: 'Given name' },
+        { name: 'last_name', name_format: 'urn:oasis:names:tc:SAML:2.0:attrname-format:basic', friendly_name: 'Family name' }
+      ],
+      :attribute_service_name             => 'Required attributes'
     }
   end
   let(:strategy) { [OmniAuth::Strategies::SAML, saml_options] }
@@ -156,6 +163,13 @@ describe OmniAuth::Strategies::SAML, :type => :strategy do
     it 'should get SP metadata page' do
       last_response.status.should == 200
       last_response.header["Content-Type"].should == "application/xml"
+    end
+
+    it 'should configure attributes consuming service' do
+      last_response.body.should match /AttributeConsumingService/
+      last_response.body.should match /first_name/
+      last_response.body.should match /last_name/
+      last_response.body.should match /Required attributes/
     end
   end
 end


### PR DESCRIPTION
Adds the omniauth's required user attributes to the `metadata.xml` as a `AttributeConsumingService` element per [section 2.4.4.1 of the metadata spec](http://docs.oasis-open.org/security/saml/v2.0/saml-metadata-2.0-os.pdf). Configurable via `:request_attributes` and `:attribute_service_name`. 

The current options don't support assigning to the `OneLogin::RubySaml::Settings#attribute_consuming_service`.