### PR TITLE
Make a copy of @options when this strategy instance is dup'd

### DIFF
--- a/lib/omniauth/strategies/saml.rb
+++ b/lib/omniauth/strategies/saml.rb
@@ -112,6 +112,15 @@ module OmniAuth
       end
 
       extra { { :raw_info => @attributes } }
+
+      protected
+
+        # Make a copy of @options when this strategy instance is dup'd in OmniAuth::Strategy#call.
+        # This allows the options to be mutated without affecting subsequent requests.
+        def initialize_copy(orig)
+          super
+          @options = @options.deep_dup
+        end
     end
   end
 end


### PR DESCRIPTION
Since `OmniAuth::Strategy#call` does `dup` before calling `call!`, this allows the `options` to be mutated without affecting subsequent requests.

Fixes #54 