### PR TITLE
Preload SAML settings before processing assertion

### DIFF
--- a/lib/omniauth/strategies/saml.rb
+++ b/lib/omniauth/strategies/saml.rb
@@ -46,8 +46,9 @@ module OmniAuth
           options.idp_cert_fingerprint = fingerprint_exists
         end
 
-        response = OneLogin::RubySaml::Response.new(request.params['SAMLResponse'], options)
-        response.settings = OneLogin::RubySaml::Settings.new(options)
+        options_with_settings = options.dup
+        options_with_settings[:settings] = OneLogin::RubySaml::Settings.new(options)
+        response = OneLogin::RubySaml::Response.new(request.params['SAMLResponse'], options_with_settings)
         response.attributes['fingerprint'] = options.idp_cert_fingerprint
 
         @name_id = response.name_id


### PR DESCRIPTION
In case we need `:private_key`, :settings should be set.