### PR TITLE
Add specs for ACS fallback URL behavior

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     omniauth-saml (1.4.2)
-      omniauth (~> 1.1)
+      omniauth (~> 1.3)
       ruby-saml (~> 1.1, >= 1.1.1)
 
 GEM

--- a/omniauth-saml.gemspec
+++ b/omniauth-saml.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |gem|
   gem.email         = 'rajiv@alum.mit.edu'
   gem.homepage      = 'https://github.com/PracticallyGreen/omniauth-saml'
 
-  gem.add_runtime_dependency 'omniauth', '~> 1.1'
+  gem.add_runtime_dependency 'omniauth', '~> 1.3'
   gem.add_runtime_dependency 'ruby-saml', '~> 1.1', '>= 1.1.1'
 
   gem.add_development_dependency 'rspec', '~> 2.8'


### PR DESCRIPTION
This PR updates `Omniauth::Strategies::SAML` to avoid mutating the `options` hash during `request_phase` and `callback_phase`. This mutation was the underlying cause of the failure reported in #54.

This PR is an alternative to the fix proposed in #56, since `deep_dup` is Rails-specific.

Let me know if you want me to drop the `Gemfile.lock` changes.

Also, I targeted this at the `master` branch instead of the `develop` branch because the latter branch is now behind.

Fixes #54 