### PR TITLE
Update `ruby-saml` to 1.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,24 +1,24 @@
 PATH
   remote: .
   specs:
-    omniauth-saml (1.3.1)
+    omniauth-saml (1.4.2)
       omniauth (~> 1.1)
-      ruby-saml (~> 1.0.0)
+      ruby-saml (~> 1.1, >= 1.1.1)
 
 GEM
   remote: https://rubygems.org/
   specs:
     diff-lcs (1.2.4)
-    hashie (3.4.2)
+    hashie (3.4.3)
     macaddr (1.7.1)
       systemu (~> 2.6.2)
-    mini_portile (0.6.2)
+    mini_portile2 (2.0.0)
     multi_json (1.3.7)
-    nokogiri (1.6.6.2)
-      mini_portile (~> 0.6.0)
-    omniauth (1.2.2)
+    nokogiri (1.6.7.1)
+      mini_portile2 (~> 2.0.0.rc2)
+    omniauth (1.3.1)
       hashie (>= 1.2, < 4)
-      rack (~> 1.0)
+      rack (>= 1.0, < 3)
     rack (1.5.2)
     rack-test (0.6.2)
       rack (>= 1.0)
@@ -30,7 +30,7 @@ GEM
     rspec-expectations (2.14.4)
       diff-lcs (>= 1.1.3, < 2.0)
     rspec-mocks (2.14.4)
-    ruby-saml (1.0.0)
+    ruby-saml (1.1.1)
       nokogiri (>= 1.5.10)
       uuid (~> 2.3)
     simplecov (0.7.1)
@@ -49,3 +49,6 @@ DEPENDENCIES
   rack-test (~> 0.6)
   rspec (~> 2.8)
   simplecov (~> 0.6)
+
+BUNDLED WITH
+   1.10.6

--- a/lib/omniauth-saml/version.rb
+++ b/lib/omniauth-saml/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module SAML
-    VERSION = '1.4.1'
+    VERSION = '1.4.2'
   end
 end

--- a/omniauth-saml.gemspec
+++ b/omniauth-saml.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |gem|
   gem.homepage      = 'https://github.com/PracticallyGreen/omniauth-saml'
 
   gem.add_runtime_dependency 'omniauth', '~> 1.1'
-  gem.add_runtime_dependency 'ruby-saml', '~> 1.0'
+  gem.add_runtime_dependency 'ruby-saml', '~> 1.1', '>= 1.1.1'
 
   gem.add_development_dependency 'rspec', '~> 2.8'
   gem.add_development_dependency 'simplecov', '~> 0.6'


### PR DESCRIPTION
Ruby SAML 1.1 was released a couple of months ago and includes some important [changes](https://github.com/onelogin/ruby-saml/blob/master/changelog.md), most importantly the support for SAMLResponse without ds:x509certificate.

This is needed for some environments where GitLab EE is running.

Also bumped the version to 1.4.1 to release a new gem.